### PR TITLE
throw type error when `.borrows` is given primitive.

### DIFF
--- a/src/joo.js
+++ b/src/joo.js
@@ -80,6 +80,7 @@
     function borrow(Class, providers) {
         for (var i = 0, l = providers.length, provider; i < l;) {
             if ((provider = providers[i++]) instanceof Function) provider = provider.prototype;
+            else if (!isObject(provider)) throw new TypeError(provider + " has no properties");
             provide(Class, provider, {'_super':1, 'constructor':1});
         }
     }
@@ -114,5 +115,9 @@
     function makeStatic(cls, properties) {
         var name, p = cls.prototype, s = p._static = p._static || {};
         for (name in properties) cls[name] = s[name] = properties[name];
+    }
+
+    function isObject(obj) {
+        return obj === Object(obj);
     }
 }());

--- a/test/spec.js
+++ b/test/spec.js
@@ -292,6 +292,24 @@ describe('.borrows() method', function() {
         expect(myObj instanceof SubClass).toBe(true);
         expect(myObj instanceof OtherProvider).toBe(false);
     });
+
+    describe('given primitive to .brrows()', function() {
+        it('threw type error', function() {
+            var descripter = def(MyClass);
+            expect(function() {
+                descripter.borrows(undefined);
+            }).toThrow(new TypeError('undefined has no properties'));
+            expect(function() {
+                descripter.borrows(null);
+            }).toThrow(new TypeError('null has no properties'));
+            expect(function() {
+                descripter.borrows(1);
+            }).toThrow(new TypeError('1 has no properties'));
+            expect(function() {
+                descripter.borrows("A");
+            }).toThrow(new TypeError('A has no properties'));
+        });
+    })  ;
 });
 
 describe('.as() method', function() {


### PR DESCRIPTION
I feel uncomfortable in that behavior which, when given a primitive value to `.borrows` is different in old ie and other.

old ie (not has debug console): throw exception
other (has debug console): Nothing happens

I think it is difficult to debug.
So I changed to throw an TypeError whenever give the primitive to `borrows`.
You can see the call-stack when error was thrown, makes debugging easier.
